### PR TITLE
Fix: Paths have leading slash

### DIFF
--- a/lib/astarte/client/appengine/devices.ex
+++ b/lib/astarte/client/appengine/devices.ex
@@ -56,7 +56,7 @@ defmodule Astarte.Client.AppEngine.Devices do
   def set_property(%AppEngine{} = client, device_id, interface, path, data)
       when is_binary(device_id) and is_binary(interface) and is_binary(path) do
     tesla_client = client.http_client
-    request_path = "devices/#{device_id}/interfaces/#{interface}/#{path}"
+    request_path = "devices/#{device_id}/interfaces/#{interface}#{path}"
 
     with {:ok, %Tesla.Env{} = result} <- Tesla.put(tesla_client, request_path, %{data: data}) do
       if result.status == 200 do
@@ -70,7 +70,7 @@ defmodule Astarte.Client.AppEngine.Devices do
   def unset_property(%AppEngine{} = client, device_id, interface, path)
       when is_binary(device_id) and is_binary(interface) and is_binary(path) do
     tesla_client = client.http_client
-    request_path = "devices/#{device_id}/interfaces/#{interface}/#{path}"
+    request_path = "devices/#{device_id}/interfaces/#{interface}#{path}"
 
     with {:ok, %Tesla.Env{} = result} <- Tesla.delete(tesla_client, request_path) do
       if result.status == 200 do
@@ -81,12 +81,19 @@ defmodule Astarte.Client.AppEngine.Devices do
     end
   end
 
-  def get_datastream_data(%AppEngine{} = client, device_id, interface, query_opts \\ [])
+  def get_datastream_data(%AppEngine{} = client, device_id, interface, opts \\ [])
       when is_binary(device_id) and is_binary(interface) do
     tesla_client = client.http_client
-    request_path = "devices/#{device_id}/interfaces/#{interface}"
+    query = Keyword.get(opts, :query, [])
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path, query: query_opts) do
+    request_path =
+      if path = opts[:path] do
+        "devices/#{device_id}/interfaces/#{interface}#{path}"
+      else
+        "devices/#{device_id}/interfaces/#{interface}"
+      end
+
+    with {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path, query: query) do
       if result.status == 200 do
         {:ok, result.body}
       else
@@ -98,7 +105,7 @@ defmodule Astarte.Client.AppEngine.Devices do
   def send_datastream(%AppEngine{} = client, device_id, interface, path, data)
       when is_binary(device_id) and is_binary(interface) and is_binary(path) do
     tesla_client = client.http_client
-    request_path = "devices/#{device_id}/interfaces/#{interface}/#{path}"
+    request_path = "devices/#{device_id}/interfaces/#{interface}#{path}"
 
     with {:ok, %Tesla.Env{} = result} <- Tesla.post(tesla_client, request_path, %{data: data}) do
       if result.status == 200 do


### PR DESCRIPTION
Mapping endpoint path starts with leading slash so passing `path` into `opts` also expect to have it
Usage:
`Devices.set_property(client, device_id, interface, "/myPath", data)`
`Devices.unset_property(client, device_id, interface, "/myPath")`
`Devices.get_datastream_data(client, device_id, interface, path: "/myPath")`
`Devices.send_datastream(client, device_id, interface, "/myPath", data)`