### PR TITLE
Add option to make create/delete Interface requests with query params

### DIFF
--- a/lib/astarte/client/realm_management/interfaces.ex
+++ b/lib/astarte/client/realm_management/interfaces.ex
@@ -60,11 +60,13 @@ defmodule Astarte.Client.RealmManagement.Interfaces do
     end
   end
 
-  def create(%RealmManagement{} = client, data) do
+  def create(%RealmManagement{} = client, data, opts \\ []) do
     request_path = "interfaces"
     tesla_client = client.http_client
+    query = Keyword.get(opts, :query, [])
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.post(tesla_client, request_path, %{data: data}) do
+    with {:ok, %Tesla.Env{} = result} <-
+           Tesla.post(tesla_client, request_path, %{data: data}, query: query) do
       if result.status == 201 do
         :ok
       else
@@ -89,12 +91,13 @@ defmodule Astarte.Client.RealmManagement.Interfaces do
     end
   end
 
-  def delete(%RealmManagement{} = client, interface_name, major_version)
+  def delete(%RealmManagement{} = client, interface_name, major_version, opts \\ [])
       when is_binary(interface_name) and is_integer(major_version) do
     request_path = "interfaces/#{interface_name}/#{major_version}"
     tesla_client = client.http_client
+    query = Keyword.get(opts, :query, [])
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.delete(tesla_client, request_path) do
+    with {:ok, %Tesla.Env{} = result} <- Tesla.delete(tesla_client, request_path, query: query) do
       if result.status == 204 do
         :ok
       else

--- a/test/astarte/client/realm_management/interfaces_test.exs
+++ b/test/astarte/client/realm_management/interfaces_test.exs
@@ -165,7 +165,7 @@ defmodule Astarte.Client.RealmManagement.InterfacesTest do
     end
   end
 
-  describe "create/2" do
+  describe "create" do
     test "makes a request to expected url using expected method", %{client: client} do
       Tesla.Mock.mock(fn %{method: method, url: url} ->
         assert method == :post
@@ -175,6 +175,18 @@ defmodule Astarte.Client.RealmManagement.InterfacesTest do
       end)
 
       Interfaces.create(client, @interface_data)
+    end
+
+    test "makes a request that includes expected query params", %{client: client} do
+      query_params = [param1: 1, param2: 2]
+
+      Tesla.Mock.mock(fn %{query: query} ->
+        assert query == query_params
+
+        %Tesla.Env{status: 201}
+      end)
+
+      Interfaces.create(client, @interface_data, query: query_params)
     end
 
     test "returns :ok if response is successful", %{client: client} do
@@ -196,7 +208,7 @@ defmodule Astarte.Client.RealmManagement.InterfacesTest do
     end
   end
 
-  describe "update/5" do
+  describe "update" do
     test "makes a request to expected url using expected method", %{client: client} do
       Tesla.Mock.mock(fn %{method: method, url: url} ->
         assert method == :put
@@ -239,7 +251,7 @@ defmodule Astarte.Client.RealmManagement.InterfacesTest do
     end
   end
 
-  describe "delete/2" do
+  describe "delete" do
     test "makes a request to expected url using expected method", %{client: client} do
       Tesla.Mock.mock(fn %{method: method, url: url} ->
         assert method == :delete
@@ -249,6 +261,18 @@ defmodule Astarte.Client.RealmManagement.InterfacesTest do
       end)
 
       Interfaces.delete(client, @interface_name, 0)
+    end
+
+    test "makes a request that includes expected query params", %{client: client} do
+      query_params = [param1: 1, param2: 2]
+
+      Tesla.Mock.mock(fn %{query: query} ->
+        assert query == query_params
+
+        %Tesla.Env{status: 201}
+      end)
+
+      Interfaces.delete(client, @interface_name, 0, query: query_params)
     end
 
     test "returns :ok if response is successful", %{client: client} do


### PR DESCRIPTION
Interface creation/deletion executed asynchronously by default,
 adds option to pass `query: [async_operation: false]` to perform the call synchronously.

`Astarte.Client.RealmManagement.Interfaces.create(client, data, query: [async_operation: false])`

`Astarte.Client.RealmManagement.Interfaces.delete(client, interface_name,
 major_version, query: [async_operation: false])`

Signed-off-by: Sergey Zakhlypa <sergey.zakhlypa@secomind.com>