### PR TITLE
Support passing JWT options for clients

### DIFF
--- a/lib/astarte/client/housekeeping.ex
+++ b/lib/astarte/client/housekeeping.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2021 SECO Mind
+# Copyright 2021-2022 SECO Mind
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ defmodule Astarte.Client.Housekeeping do
 
   @spec new(String.t(), Keyword.t()) :: {:ok, t()} | {:error, any}
   def new(base_api_url, opts) when is_binary(base_api_url) and is_list(opts) do
-    with {:ok, jwt} <- fetch_jwt(opts) do
+    with {:ok, jwt} <- fetch_or_generate_jwt(opts) do
       base_url = Path.join([base_api_url, "housekeeping", "v1"])
 
       middleware = [
@@ -45,20 +45,34 @@ defmodule Astarte.Client.Housekeeping do
     end
   end
 
-  defp fetch_jwt(opts) do
-    with :error <- Keyword.fetch(opts, :jwt) do
-      opts
-      |> Keyword.get(:private_key)
-      |> generate_jwt()
+  defp fetch_or_generate_jwt(opts) when is_list(opts) do
+    with {:error, :missing_jwt} <- fetch_jwt(opts),
+         {:error, :missing_private_key} <- generate_jwt(opts) do
+      {:error, :missing_jwt_and_private_key}
     end
   end
 
-  defp generate_jwt(nil = _private_key) do
-    {:error, :missing_jwt_and_private_key}
+  defp fetch_jwt(opts) when is_list(opts) do
+    case Keyword.fetch(opts, :jwt) do
+      {:ok, jwt} when is_binary(jwt) ->
+        {:ok, jwt}
+
+      :error ->
+        {:error, :missing_jwt}
+    end
   end
 
-  defp generate_jwt(private_key) when is_binary(private_key) do
-    Credentials.housekeeping_all_access_credentials(expiry: @jwt_expiry)
-    |> Credentials.to_jwt(private_key)
+  defp generate_jwt(opts) when is_list(opts) do
+    case Keyword.fetch(opts, :private_key) do
+      {:ok, private_key} when is_binary(private_key) ->
+        opts
+        |> Keyword.get(:jwt_opts, [])
+        |> Keyword.put_new(:expiry, @jwt_expiry)
+        |> Credentials.housekeeping_all_access_credentials()
+        |> Credentials.to_jwt(private_key)
+
+      :error ->
+        {:error, :missing_private_key}
+    end
   end
 end

--- a/lib/astarte/client/realm_management.ex
+++ b/lib/astarte/client/realm_management.ex
@@ -32,7 +32,7 @@ defmodule Astarte.Client.RealmManagement do
   @spec new(String.t(), String.t(), Keyword.t()) :: {:ok, t()} | {:error, any}
   def new(base_api_url, realm_name, opts)
       when is_binary(base_api_url) and is_binary(realm_name) and is_list(opts) do
-    with {:ok, jwt} <- fetch_jwt(opts) do
+    with {:ok, jwt} <- fetch_or_generate_jwt(opts) do
       base_url = Path.join([base_api_url, "realmmanagement", "v1", realm_name])
 
       middleware = [
@@ -46,20 +46,34 @@ defmodule Astarte.Client.RealmManagement do
     end
   end
 
-  defp fetch_jwt(opts) do
-    with :error <- Keyword.fetch(opts, :jwt) do
-      opts
-      |> Keyword.get(:private_key)
-      |> generate_jwt()
+  defp fetch_or_generate_jwt(opts) when is_list(opts) do
+    with {:error, :missing_jwt} <- fetch_jwt(opts),
+         {:error, :missing_private_key} <- generate_jwt(opts) do
+      {:error, :missing_jwt_and_private_key}
     end
   end
 
-  defp generate_jwt(nil = _private_key) do
-    {:error, :missing_jwt_and_private_key}
+  defp fetch_jwt(opts) when is_list(opts) do
+    case Keyword.fetch(opts, :jwt) do
+      {:ok, jwt} when is_binary(jwt) ->
+        {:ok, jwt}
+
+      :error ->
+        {:error, :missing_jwt}
+    end
   end
 
-  defp generate_jwt(private_key) when is_binary(private_key) do
-    Credentials.realm_management_all_access_credentials(expiry: @jwt_expiry)
-    |> Credentials.to_jwt(private_key)
+  defp generate_jwt(opts) when is_list(opts) do
+    case Keyword.fetch(opts, :private_key) do
+      {:ok, private_key} when is_binary(private_key) ->
+        opts
+        |> Keyword.get(:jwt_opts, [])
+        |> Keyword.put_new(:expiry, @jwt_expiry)
+        |> Credentials.realm_management_all_access_credentials()
+        |> Credentials.to_jwt(private_key)
+
+      _ ->
+        {:error, :missing_private_key}
+    end
   end
 end

--- a/test/astarte/client/appengine_test.exs
+++ b/test/astarte/client/appengine_test.exs
@@ -29,6 +29,7 @@ defmodule Astarte.Client.AppEngineTest do
   @valid_private_key X509.PrivateKey.new_ec(:secp256r1) |> X509.PrivateKey.to_pem()
   @invalid_private_key "notaprivatekey"
   @device_id "device_id"
+  @signer Joken.Signer.create("ES256", %{"pem" => @valid_private_key})
 
   describe "new/3" do
     test "with jwt creates client" do
@@ -73,6 +74,55 @@ defmodule Astarte.Client.AppEngineTest do
 
     test "without jwt and private_key returns error" do
       assert {:error, :missing_jwt_and_private_key} = AppEngine.new(@base_url, @realm_name, [])
+    end
+
+    test "without jwt_opts generates JWT with issuer and expiration time claims" do
+      assert {:ok, %AppEngine{} = client} =
+               AppEngine.new(@base_url, @realm_name, private_key: @valid_private_key)
+
+      Tesla.Mock.mock(fn env ->
+        assert "Bearer: " <> jwt = Tesla.get_header(env, "Authorization")
+        assert {:ok, claims} = Joken.verify(jwt, @signer)
+
+        assert %{
+                 "a_aea" => _,
+                 "iss" => _,
+                 "exp" => _
+               } = claims
+
+        %Tesla.Env{status: 200}
+      end)
+
+      assert {:ok, _} = Devices.get_device_status(client, @device_id)
+    end
+
+    test "with jwt_opts generates JWT with requested claims" do
+      issuer = "foo"
+      subject = "bar"
+      expiry = :infinity
+
+      assert {:ok, %AppEngine{} = client} =
+               AppEngine.new(@base_url, @realm_name,
+                 private_key: @valid_private_key,
+                 jwt_opts: [issuer: issuer, subject: subject, expiry: expiry]
+               )
+
+      Tesla.Mock.mock(fn env ->
+        assert "Bearer: " <> jwt = Tesla.get_header(env, "Authorization")
+        assert {:ok, claims} = Joken.verify(jwt, @signer)
+
+        assert %{
+                 "a_aea" => _,
+                 "iss" => ^issuer,
+                 "sub" => ^subject
+               } = claims
+
+        refute is_map_key(claims, "exp")
+
+        %Tesla.Env{status: 200}
+      end)
+
+      assert {:ok, _} = Devices.get_device_status(client, @device_id)
     end
 
     test "the client uses the information to perform the request" do


### PR DESCRIPTION
Adds feature to add JWT claims to generated JWT passing optional `:jwt_opts` keyword list alongside with `:private_key`

The accepted options for `:jwt_opts` are:

    - `:issuer`  - the "iss" (issuer) claim
    - `:subject` - the "sub" (subject) claim
    - `:expiry` - how to generate the "exp" (expiration time) claim. The possible values are:
      - `:infinity` - do not add expiration time claim
      - `positive integer` - the amount of time in seconds to be added to the current time
      at JWT generation moment

```elixir

# without custom claims
Astarte.Client.AppEngine.new("https://api.eu1.astarte.cloud", "myrealm",
  private_key: private_key)
# Generated JWT has:
#  "iss": "Astarte Client Elixir v0.1.0"
#  "exp" <- now() + 5 min

# with custom claims
Astarte.Client.AppEngine.new("https://api.eu1.astarte.cloud", "myrealm",
  private_key: private_key,
  jwt_opts: [
    issuer: "foo",
    subject: "bar",
    expiry: :infinity
])
# Generated JWT has:
#  "iss": "foo",
#  "sub": "bar"
#  no "exp" claim

```