### PR TITLE
Generate new JWT from private_key for every request

### DIFF
--- a/lib/astarte/client/appengine.ex
+++ b/lib/astarte/client/appengine.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2021-2022 SECO Mind
+# Copyright 2021-2023 SECO Mind
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,32 +17,47 @@
 #
 
 defmodule Astarte.Client.AppEngine do
-  @enforce_keys [:http_client]
-  defstruct @enforce_keys
-
-  @type t :: %__MODULE__{
-          http_client: Tesla.Client.t()
-        }
-
-  alias __MODULE__
   alias Astarte.Client.Credentials
 
   @jwt_expiry 5 * 60
+  @enforce_keys [:base_url, :opts]
 
-  @spec new(String.t(), String.t(), Keyword.t()) :: {:ok, t()} | {:error, any}
+  defstruct @enforce_keys
+
+  @type jwt_option :: {:issuer, binary} | {:subject, binary} | {:expiry, pos_integer | :infinity}
+  @type option :: {:jwt, binary} | {:private_key, binary} | {:jwt_opts, [jwt_option, ...]}
+  @type t :: %__MODULE__{
+          base_url: binary,
+          opts: [option, ...]
+        }
+
+  @spec new(String.t(), String.t(), Keyword.t()) :: {:ok, t} | {:error, any}
   def new(base_api_url, realm_name, opts)
       when is_binary(base_api_url) and is_binary(realm_name) and is_list(opts) do
-    with {:ok, jwt} <- fetch_or_generate_jwt(opts) do
+    with {:ok, _jwt} <- fetch_or_generate_jwt(opts) do
       base_url = Path.join([base_api_url, "appengine", "v1", realm_name])
 
+      {:ok,
+       %__MODULE__{
+         base_url: base_url,
+         opts: opts
+       }}
+    end
+  end
+
+  @doc false
+  @spec fetch_tesla_client(t) :: {:ok, Tesla.Client.t()} | {:error, any}
+  def fetch_tesla_client(%__MODULE__{} = appengine_client) do
+    %__MODULE__{base_url: base_url, opts: opts} = appengine_client
+
+    with {:ok, jwt} <- fetch_or_generate_jwt(opts) do
       middleware = [
         {Tesla.Middleware.BaseUrl, base_url},
         Tesla.Middleware.JSON,
         {Tesla.Middleware.Headers, [{"Authorization", "Bearer: " <> jwt}]}
       ]
 
-      http_client = Tesla.client(middleware)
-      {:ok, %AppEngine{http_client: http_client}}
+      {:ok, Tesla.client(middleware)}
     end
   end
 

--- a/lib/astarte/client/appengine/devices.ex
+++ b/lib/astarte/client/appengine/devices.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2021 SECO Mind
+# Copyright 2021-2023 SECO Mind
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,9 +33,9 @@ defmodule Astarte.Client.AppEngine.Devices do
 
   def get_device_status(%AppEngine{} = client, device_id) when is_binary(device_id) do
     request_path = "devices/#{device_id}"
-    tesla_client = client.http_client
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path) do
+    with {:ok, tesla_client} <- AppEngine.fetch_tesla_client(client),
+         {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path) do
       if result.status == 200 do
         {:ok, result.body}
       else
@@ -46,9 +46,9 @@ defmodule Astarte.Client.AppEngine.Devices do
 
   def get_device_interfaces(%AppEngine{} = client, device_id) do
     request_path = "devices/#{device_id}/interfaces"
-    tesla_client = client.http_client
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path) do
+    with {:ok, tesla_client} <- AppEngine.fetch_tesla_client(client),
+         {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path) do
       if result.status == 200 do
         {:ok, result.body}
       else
@@ -59,7 +59,6 @@ defmodule Astarte.Client.AppEngine.Devices do
 
   def get_properties_data(%AppEngine{} = client, device_id, interface, opts \\ [])
       when is_binary(device_id) and is_binary(interface) do
-    tesla_client = client.http_client
     query = Keyword.get(opts, :query, [])
 
     request_path =
@@ -69,7 +68,8 @@ defmodule Astarte.Client.AppEngine.Devices do
         "devices/#{device_id}/interfaces/#{interface}"
       end
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path, query: query) do
+    with {:ok, tesla_client} <- AppEngine.fetch_tesla_client(client),
+         {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path, query: query) do
       if result.status == 200 do
         {:ok, result.body}
       else
@@ -80,10 +80,10 @@ defmodule Astarte.Client.AppEngine.Devices do
 
   def set_property(%AppEngine{} = client, device_id, interface, path, data)
       when is_binary(device_id) and is_binary(interface) and is_binary(path) do
-    tesla_client = client.http_client
     request_path = "devices/#{device_id}/interfaces/#{interface}#{path}"
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.put(tesla_client, request_path, %{data: data}) do
+    with {:ok, tesla_client} <- AppEngine.fetch_tesla_client(client),
+         {:ok, %Tesla.Env{} = result} <- Tesla.put(tesla_client, request_path, %{data: data}) do
       if result.status == 200 do
         :ok
       else
@@ -94,10 +94,10 @@ defmodule Astarte.Client.AppEngine.Devices do
 
   def unset_property(%AppEngine{} = client, device_id, interface, path)
       when is_binary(device_id) and is_binary(interface) and is_binary(path) do
-    tesla_client = client.http_client
     request_path = "devices/#{device_id}/interfaces/#{interface}#{path}"
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.delete(tesla_client, request_path) do
+    with {:ok, tesla_client} <- AppEngine.fetch_tesla_client(client),
+         {:ok, %Tesla.Env{} = result} <- Tesla.delete(tesla_client, request_path) do
       if result.status == 204 do
         :ok
       else
@@ -108,7 +108,6 @@ defmodule Astarte.Client.AppEngine.Devices do
 
   def get_datastream_data(%AppEngine{} = client, device_id, interface, opts \\ [])
       when is_binary(device_id) and is_binary(interface) do
-    tesla_client = client.http_client
     query = Keyword.get(opts, :query, [])
 
     request_path =
@@ -118,7 +117,8 @@ defmodule Astarte.Client.AppEngine.Devices do
         "devices/#{device_id}/interfaces/#{interface}"
       end
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path, query: query) do
+    with {:ok, tesla_client} <- AppEngine.fetch_tesla_client(client),
+         {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path, query: query) do
       if result.status == 200 do
         {:ok, result.body}
       else
@@ -129,10 +129,10 @@ defmodule Astarte.Client.AppEngine.Devices do
 
   def send_datastream(%AppEngine{} = client, device_id, interface, path, data)
       when is_binary(device_id) and is_binary(interface) and is_binary(path) do
-    tesla_client = client.http_client
     request_path = "devices/#{device_id}/interfaces/#{interface}#{path}"
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.post(tesla_client, request_path, %{data: data}) do
+    with {:ok, tesla_client} <- AppEngine.fetch_tesla_client(client),
+         {:ok, %Tesla.Env{} = result} <- Tesla.post(tesla_client, request_path, %{data: data}) do
       if result.status == 200 do
         :ok
       else

--- a/lib/astarte/client/appengine/groups.ex
+++ b/lib/astarte/client/appengine/groups.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2021,2022 SECO Mind
+# Copyright 2021-2023 SECO Mind
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,9 +22,9 @@ defmodule Astarte.Client.AppEngine.Groups do
 
   def list(%AppEngine{} = client) do
     request_path = "groups"
-    tesla_client = client.http_client
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path) do
+    with {:ok, tesla_client} <- AppEngine.fetch_tesla_client(client),
+         {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path) do
       if result.status == 200 do
         {:ok, result.body}
       else
@@ -36,10 +36,10 @@ defmodule Astarte.Client.AppEngine.Groups do
   def create(%AppEngine{} = client, group_name, devices)
       when is_binary(group_name) and is_list(devices) do
     request_path = "groups"
-    tesla_client = client.http_client
     body = %{data: %{group_name: group_name, devices: devices}}
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.post(tesla_client, request_path, body) do
+    with {:ok, tesla_client} <- AppEngine.fetch_tesla_client(client),
+         {:ok, %Tesla.Env{} = result} <- Tesla.post(tesla_client, request_path, body) do
       if result.status == 201 do
         :ok
       else
@@ -50,9 +50,9 @@ defmodule Astarte.Client.AppEngine.Groups do
 
   def get(%AppEngine{} = client, group_name) when is_binary(group_name) do
     request_path = "groups/#{group_name}"
-    tesla_client = client.http_client
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path) do
+    with {:ok, tesla_client} <- AppEngine.fetch_tesla_client(client),
+         {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path) do
       if result.status == 200 do
         {:ok, result.body}
       else
@@ -77,10 +77,10 @@ defmodule Astarte.Client.AppEngine.Groups do
   def add_device(%AppEngine{} = client, group_name, device_id)
       when is_binary(group_name) and is_binary(device_id) do
     request_path = "groups/#{group_name}/devices"
-    tesla_client = client.http_client
     body = %{data: %{device_id: device_id}}
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.post(tesla_client, request_path, body) do
+    with {:ok, tesla_client} <- AppEngine.fetch_tesla_client(client),
+         {:ok, %Tesla.Env{} = result} <- Tesla.post(tesla_client, request_path, body) do
       if result.status == 201 do
         :ok
       else
@@ -92,9 +92,9 @@ defmodule Astarte.Client.AppEngine.Groups do
   def remove_device(%AppEngine{} = client, group_name, device_id)
       when is_binary(group_name) and is_binary(device_id) do
     request_path = "groups/#{group_name}/devices/#{device_id}"
-    tesla_client = client.http_client
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.delete(tesla_client, request_path) do
+    with {:ok, tesla_client} <- AppEngine.fetch_tesla_client(client),
+         {:ok, %Tesla.Env{} = result} <- Tesla.delete(tesla_client, request_path) do
       if result.status == 204 do
         :ok
       else

--- a/lib/astarte/client/appengine/stats.ex
+++ b/lib/astarte/client/appengine/stats.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2021 SECO Mind
+# Copyright 2021-2023 SECO Mind
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,9 +21,9 @@ defmodule Astarte.Client.AppEngine.Stats do
 
   def get_devices_stats(%AppEngine{} = client) do
     request_path = "stats/devices"
-    tesla_client = client.http_client
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path) do
+    with {:ok, tesla_client} <- AppEngine.fetch_tesla_client(client),
+         {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path) do
       if result.status == 200 do
         {:ok, result.body}
       else

--- a/lib/astarte/client/pairing.ex
+++ b/lib/astarte/client/pairing.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2022 SECO Mind
+# Copyright 2022-2023 SECO Mind
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,31 +17,47 @@
 #
 
 defmodule Astarte.Client.Pairing do
-  @enforce_keys [:http_client]
-  defstruct @enforce_keys
-
-  @type t :: %__MODULE__{
-          http_client: Tesla.Client.t()
-        }
-
   alias Astarte.Client.Credentials
 
   @jwt_expiry 5 * 60
+  @enforce_keys [:base_url, :opts]
+
+  defstruct @enforce_keys
+
+  @type jwt_option :: {:issuer, binary} | {:subject, binary} | {:expiry, pos_integer | :infinity}
+  @type option :: {:jwt, binary} | {:private_key, binary} | {:jwt_opts, [jwt_option, ...]}
+  @type t :: %__MODULE__{
+          base_url: binary,
+          opts: [option, ...]
+        }
 
   @spec new(String.t(), String.t(), Keyword.t()) :: {:ok, t()} | {:error, any}
   def new(base_api_url, realm_name, opts)
       when is_binary(base_api_url) and is_binary(realm_name) and is_list(opts) do
-    with {:ok, jwt} <- fetch_or_generate_jwt(opts) do
+    with {:ok, _jwt} <- fetch_or_generate_jwt(opts) do
       base_url = Path.join([base_api_url, "pairing", "v1", realm_name])
 
+      {:ok,
+       %__MODULE__{
+         base_url: base_url,
+         opts: opts
+       }}
+    end
+  end
+
+  @doc false
+  @spec fetch_tesla_client(t) :: {:ok, Tesla.Client.t()} | {:error, any}
+  def fetch_tesla_client(%__MODULE__{} = pairing_client) do
+    %__MODULE__{base_url: base_url, opts: opts} = pairing_client
+
+    with {:ok, jwt} <- fetch_or_generate_jwt(opts) do
       middleware = [
         {Tesla.Middleware.BaseUrl, base_url},
         Tesla.Middleware.JSON,
         {Tesla.Middleware.Headers, [{"Authorization", "Bearer: " <> jwt}]}
       ]
 
-      http_client = Tesla.client(middleware)
-      {:ok, %__MODULE__{http_client: http_client}}
+      {:ok, Tesla.client(middleware)}
     end
   end
 

--- a/lib/astarte/client/pairing/agent.ex
+++ b/lib/astarte/client/pairing/agent.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2022 SECO Mind
+# Copyright 2022-2023 SECO Mind
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,9 +21,9 @@ defmodule Astarte.Client.Pairing.Agent do
 
   def register(%Pairing{} = client, data) when is_map(data) do
     request_path = "agent/devices"
-    tesla_client = client.http_client
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.post(tesla_client, request_path, %{data: data}) do
+    with {:ok, tesla_client} <- Pairing.fetch_tesla_client(client),
+         {:ok, %Tesla.Env{} = result} <- Tesla.post(tesla_client, request_path, %{data: data}) do
       if result.status == 201 do
         {:ok, result.body}
       else
@@ -34,9 +34,9 @@ defmodule Astarte.Client.Pairing.Agent do
 
   def unregister(%Pairing{} = client, device_id) when is_binary(device_id) do
     request_path = "agent/devices/#{device_id}"
-    tesla_client = client.http_client
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.delete(tesla_client, request_path) do
+    with {:ok, tesla_client} <- Pairing.fetch_tesla_client(client),
+         {:ok, %Tesla.Env{} = result} <- Tesla.delete(tesla_client, request_path) do
       if result.status == 204 do
         :ok
       else

--- a/lib/astarte/client/realm_management.ex
+++ b/lib/astarte/client/realm_management.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2022 SECO Mind
+# Copyright 2022-2023 SECO Mind
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,32 +17,47 @@
 #
 
 defmodule Astarte.Client.RealmManagement do
-  @enforce_keys [:http_client]
-  defstruct @enforce_keys
-
-  @type t :: %__MODULE__{
-          http_client: Tesla.Client.t()
-        }
-
-  alias __MODULE__
   alias Astarte.Client.Credentials
 
   @jwt_expiry 5 * 60
+  @enforce_keys [:base_url, :opts]
+
+  defstruct @enforce_keys
+
+  @type jwt_option :: {:issuer, binary} | {:subject, binary} | {:expiry, pos_integer | :infinity}
+  @type option :: {:jwt, binary} | {:private_key, binary} | {:jwt_opts, [jwt_option, ...]}
+  @type t :: %__MODULE__{
+          base_url: binary,
+          opts: [option, ...]
+        }
 
   @spec new(String.t(), String.t(), Keyword.t()) :: {:ok, t()} | {:error, any}
   def new(base_api_url, realm_name, opts)
       when is_binary(base_api_url) and is_binary(realm_name) and is_list(opts) do
-    with {:ok, jwt} <- fetch_or_generate_jwt(opts) do
+    with {:ok, _jwt} <- fetch_or_generate_jwt(opts) do
       base_url = Path.join([base_api_url, "realmmanagement", "v1", realm_name])
 
+      {:ok,
+       %__MODULE__{
+         base_url: base_url,
+         opts: opts
+       }}
+    end
+  end
+
+  @doc false
+  @spec fetch_tesla_client(t) :: {:ok, Tesla.Client.t()} | {:error, any}
+  def fetch_tesla_client(%__MODULE__{} = realm_management_client) do
+    %__MODULE__{base_url: base_url, opts: opts} = realm_management_client
+
+    with {:ok, jwt} <- fetch_or_generate_jwt(opts) do
       middleware = [
         {Tesla.Middleware.BaseUrl, base_url},
         Tesla.Middleware.JSON,
         {Tesla.Middleware.Headers, [{"Authorization", "Bearer: " <> jwt}]}
       ]
 
-      http_client = Tesla.client(middleware)
-      {:ok, %RealmManagement{http_client: http_client}}
+      {:ok, Tesla.client(middleware)}
     end
   end
 

--- a/lib/astarte/client/realm_management/interfaces.ex
+++ b/lib/astarte/client/realm_management/interfaces.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2022 SECO Mind
+# Copyright 2022-2023 SECO Mind
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,9 +21,9 @@ defmodule Astarte.Client.RealmManagement.Interfaces do
 
   def list(%RealmManagement{} = client) do
     request_path = "interfaces"
-    tesla_client = client.http_client
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path) do
+    with {:ok, tesla_client} <- RealmManagement.fetch_tesla_client(client),
+         {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path) do
       if result.status == 200 do
         {:ok, result.body}
       else
@@ -35,9 +35,9 @@ defmodule Astarte.Client.RealmManagement.Interfaces do
   def list_major_versions(%RealmManagement{} = client, interface_name)
       when is_binary(interface_name) do
     request_path = "interfaces/#{interface_name}"
-    tesla_client = client.http_client
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path) do
+    with {:ok, tesla_client} <- RealmManagement.fetch_tesla_client(client),
+         {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path) do
       if result.status == 200 do
         {:ok, result.body}
       else
@@ -49,9 +49,9 @@ defmodule Astarte.Client.RealmManagement.Interfaces do
   def get(%RealmManagement{} = client, interface_name, major_version)
       when is_binary(interface_name) and is_integer(major_version) do
     request_path = "interfaces/#{interface_name}/#{major_version}"
-    tesla_client = client.http_client
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path) do
+    with {:ok, tesla_client} <- RealmManagement.fetch_tesla_client(client),
+         {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path) do
       if result.status == 200 do
         {:ok, result.body}
       else
@@ -62,10 +62,10 @@ defmodule Astarte.Client.RealmManagement.Interfaces do
 
   def create(%RealmManagement{} = client, data, opts \\ []) do
     request_path = "interfaces"
-    tesla_client = client.http_client
     query = Keyword.get(opts, :query, [])
 
-    with {:ok, %Tesla.Env{} = result} <-
+    with {:ok, tesla_client} <- RealmManagement.fetch_tesla_client(client),
+         {:ok, %Tesla.Env{} = result} <-
            Tesla.post(tesla_client, request_path, %{data: data}, query: query) do
       if result.status == 201 do
         :ok
@@ -78,10 +78,10 @@ defmodule Astarte.Client.RealmManagement.Interfaces do
   def update(%RealmManagement{} = client, interface_name, major_version, data, opts \\ [])
       when is_binary(interface_name) and is_integer(major_version) do
     request_path = "interfaces/#{interface_name}/#{major_version}"
-    tesla_client = client.http_client
     query = Keyword.get(opts, :query, [])
 
-    with {:ok, %Tesla.Env{} = result} <-
+    with {:ok, tesla_client} <- RealmManagement.fetch_tesla_client(client),
+         {:ok, %Tesla.Env{} = result} <-
            Tesla.put(tesla_client, request_path, %{data: data}, query: query) do
       if result.status == 204 do
         :ok
@@ -94,10 +94,10 @@ defmodule Astarte.Client.RealmManagement.Interfaces do
   def delete(%RealmManagement{} = client, interface_name, major_version, opts \\ [])
       when is_binary(interface_name) and is_integer(major_version) do
     request_path = "interfaces/#{interface_name}/#{major_version}"
-    tesla_client = client.http_client
     query = Keyword.get(opts, :query, [])
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.delete(tesla_client, request_path, query: query) do
+    with {:ok, tesla_client} <- RealmManagement.fetch_tesla_client(client),
+         {:ok, %Tesla.Env{} = result} <- Tesla.delete(tesla_client, request_path, query: query) do
       if result.status == 204 do
         :ok
       else

--- a/lib/astarte/client/realm_management/realm_config.ex
+++ b/lib/astarte/client/realm_management/realm_config.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2022 SECO Mind
+# Copyright 2022-2023 SECO Mind
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,9 +21,9 @@ defmodule Astarte.Client.RealmManagement.RealmConfig do
 
   def get_auth_config(%RealmManagement{} = client) do
     request_path = "config/auth"
-    tesla_client = client.http_client
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path) do
+    with {:ok, tesla_client} <- RealmManagement.fetch_tesla_client(client),
+         {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path) do
       if result.status == 200 do
         {:ok, result.body}
       else
@@ -34,9 +34,9 @@ defmodule Astarte.Client.RealmManagement.RealmConfig do
 
   def set_auth_config(%RealmManagement{} = client, data) do
     request_path = "config/auth"
-    tesla_client = client.http_client
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.put(tesla_client, request_path, %{data: data}) do
+    with {:ok, tesla_client} <- RealmManagement.fetch_tesla_client(client),
+         {:ok, %Tesla.Env{} = result} <- Tesla.put(tesla_client, request_path, %{data: data}) do
       if result.status == 204 do
         :ok
       else

--- a/lib/astarte/client/realm_management/triggers.ex
+++ b/lib/astarte/client/realm_management/triggers.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2022 SECO Mind
+# Copyright 2022-2023 SECO Mind
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,9 +21,9 @@ defmodule Astarte.Client.RealmManagement.Triggers do
 
   def list(%RealmManagement{} = client) do
     request_path = "triggers"
-    tesla_client = client.http_client
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path) do
+    with {:ok, tesla_client} <- RealmManagement.fetch_tesla_client(client),
+         {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path) do
       if result.status == 200 do
         {:ok, result.body}
       else
@@ -34,9 +34,9 @@ defmodule Astarte.Client.RealmManagement.Triggers do
 
   def get(%RealmManagement{} = client, trigger_name) when is_binary(trigger_name) do
     request_path = "triggers/#{trigger_name}"
-    tesla_client = client.http_client
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path) do
+    with {:ok, tesla_client} <- RealmManagement.fetch_tesla_client(client),
+         {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path) do
       if result.status == 200 do
         {:ok, result.body}
       else
@@ -47,9 +47,9 @@ defmodule Astarte.Client.RealmManagement.Triggers do
 
   def create(%RealmManagement{} = client, data) do
     request_path = "triggers"
-    tesla_client = client.http_client
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.post(tesla_client, request_path, %{data: data}) do
+    with {:ok, tesla_client} <- RealmManagement.fetch_tesla_client(client),
+         {:ok, %Tesla.Env{} = result} <- Tesla.post(tesla_client, request_path, %{data: data}) do
       if result.status == 201 do
         :ok
       else
@@ -60,9 +60,9 @@ defmodule Astarte.Client.RealmManagement.Triggers do
 
   def delete(%RealmManagement{} = client, trigger_name) when is_binary(trigger_name) do
     request_path = "triggers/#{trigger_name}"
-    tesla_client = client.http_client
 
-    with {:ok, %Tesla.Env{} = result} <- Tesla.delete(tesla_client, request_path) do
+    with {:ok, tesla_client} <- RealmManagement.fetch_tesla_client(client),
+         {:ok, %Tesla.Env{} = result} <- Tesla.delete(tesla_client, request_path) do
       if result.status == 204 do
         :ok
       else


### PR DESCRIPTION
Clients will generate new JWT for every request with provided `private_key` and `jwt_opts`

Signed-off-by: Sergey Zakhlypa <sergey.zakhlypa@secomind.com>