### PR TITLE
Housekeeping: support updating realms configuration

### DIFF
--- a/lib/astarte/client/housekeeping/realms.ex
+++ b/lib/astarte/client/housekeeping/realms.ex
@@ -126,6 +126,40 @@ defmodule Astarte.Client.Housekeeping.Realms do
   end
 
   @doc """
+  Updates a realm.
+
+  ## Examples
+
+    Astarte.Client.Housekeeping.Realms.update(client, realm_name, [jwt_public_key_pem: "..."])
+
+    Astarte.Client.Housekeeping.Realms.update(client, realm_name, [device_registration_limit: 100])
+
+  """
+  def update(%Housekeeping{} = client, realm_name, opts)
+      when is_binary(realm_name) and is_list(opts) do
+    request_path = "realms/#{realm_name}"
+    tesla_client = client.http_client
+
+    realm_data =
+      [:jwt_public_key_pem, :device_registration_limit]
+      |> Enum.reduce(%{}, fn key, acc ->
+        case Keyword.fetch(opts, key) do
+          {:ok, value} -> Map.put(acc, key, value)
+          :error -> acc
+        end
+      end)
+
+    with {:ok, %Tesla.Env{} = result} <-
+           Tesla.patch(tesla_client, request_path, %{data: realm_data}) do
+      if result.status == 200 do
+        :ok
+      else
+        {:error, %APIError{status: result.status, response: result.body}}
+      end
+    end
+  end
+
+  @doc """
   Deletes a realm.
 
   ## Examples

--- a/lib/astarte/client/housekeeping/realms.ex
+++ b/lib/astarte/client/housekeeping/realms.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2021 SECO Mind
+# Copyright 2021-2024 SECO Mind
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -47,10 +47,12 @@ defmodule Astarte.Client.Housekeeping.Realms do
     request_path = "realms"
     tesla_client = client.http_client
     query = Keyword.get(opts, :query, [])
+    device_registration_limit = Keyword.get(opts, :device_registration_limit)
 
     data = %{
       realm_name: realm_name,
-      jwt_public_key_pem: public_key_pem
+      jwt_public_key_pem: public_key_pem,
+      device_registration_limit: device_registration_limit
     }
 
     with {:ok, replication_data} <- fetch_replication(opts),

--- a/test/astarte/client/housekeeping/realms_test.exs
+++ b/test/astarte/client/housekeeping/realms_test.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2022 SECO Mind
+# Copyright 2022-2024 SECO Mind
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,418 @@ defmodule Astarte.Client.Housekeeping.RealmsTest do
   use ExUnit.Case
   doctest Astarte.Client.Housekeeping.Realms
 
+  alias Astarte.Client.APIError
+  alias Astarte.Client.Housekeeping
   alias Astarte.Client.Housekeeping.Realms
+
+  @base_url "https://base-url.com"
+  @jwt "notarealjwt"
+  @realm_name "myrealm"
+  @realm_public_key X509.PrivateKey.new_ec(:secp256r1)
+                    |> X509.PublicKey.derive()
+                    |> X509.PublicKey.to_pem()
+
+  setup do
+    {:ok, %Housekeeping{} = client} = Housekeeping.new(@base_url, jwt: @jwt)
+
+    {:ok, client: client}
+  end
+
+  describe "list/1" do
+    test "makes a request to expected url using expected method", %{client: client} do
+      Tesla.Mock.mock(fn %{method: method, url: url} ->
+        assert method == :get
+        assert url == build_realm_url()
+
+        Tesla.Mock.json(
+          %{"data" => []},
+          status: 200
+        )
+      end)
+
+      Realms.list(client)
+    end
+
+    test "returns list of existing realms", %{client: client} do
+      Tesla.Mock.mock(fn %{} ->
+        Tesla.Mock.json(
+          %{"data" => ["realm1", "realm2"]},
+          status: 200
+        )
+      end)
+
+      assert {:ok, %{"data" => ["realm1", "realm2"]}} = Realms.list(client)
+    end
+
+    test "retuns APIError on error", %{client: client} do
+      error_data = %{"errors" => %{"detail" => "Forbidden"}}
+      error_status = 403
+
+      Tesla.Mock.mock(fn %{} ->
+        Tesla.Mock.json(error_data, status: error_status)
+      end)
+
+      assert {:error, %APIError{response: error_data, status: error_status}} ==
+               Realms.list(client)
+    end
+  end
+
+  describe "get/2" do
+    test "makes a request to expected url using expected method", %{client: client} do
+      Tesla.Mock.mock(fn %{method: method, url: url} ->
+        assert method == :get
+        assert url == build_realm_url("myrealm")
+
+        Tesla.Mock.json(
+          realm_response(),
+          status: 200
+        )
+      end)
+
+      Realms.get(client, "myrealm")
+    end
+
+    test "returns realm configuration", %{client: client} do
+      Tesla.Mock.mock(fn %{} ->
+        Tesla.Mock.json(
+          realm_response(realm_name: "myrealm"),
+          status: 200
+        )
+      end)
+
+      assert {:ok,
+              %{
+                "data" => %{
+                  "datastream_maximum_storage_retention" => nil,
+                  "device_registration_limit" => nil,
+                  "jwt_public_key_pem" => "-----BEGIN PUBLIC KEY-----" <> _,
+                  "realm_name" => "myrealm",
+                  "replication_class" => "SimpleStrategy",
+                  "replication_factor" => 1
+                }
+              }} = Realms.get(client, "myrealm")
+    end
+
+    test "retuns APIError on error", %{client: client} do
+      error_data = %{"errors" => %{"detail" => "Forbidden"}}
+      error_status = 403
+
+      Tesla.Mock.mock(fn %{} ->
+        Tesla.Mock.json(error_data, status: error_status)
+      end)
+
+      assert {:error, %APIError{response: error_data, status: error_status}} ==
+               Realms.get(client, "myrealm")
+    end
+  end
+
+  describe "create/4" do
+    test "makes a request to expected url using expected method", %{client: client} do
+      Tesla.Mock.mock(fn %{method: method, url: url} ->
+        assert method == :post
+        assert url == build_realm_url()
+
+        Tesla.Mock.json(
+          realm_response(),
+          status: 201
+        )
+      end)
+
+      Realms.create(client, @realm_name, @realm_public_key, replication_factor: 1)
+    end
+
+    test "specifies query parameters", %{client: client} do
+      opts = [query: [async_operation: false]]
+
+      Tesla.Mock.mock(fn %{query: query} ->
+        assert query == [async_operation: false]
+
+        Tesla.Mock.json(realm_response(), status: 201)
+      end)
+
+      assert :ok =
+               Realms.create(
+                 client,
+                 @realm_name,
+                 @realm_public_key,
+                 [replication_factor: 1] ++ opts
+               )
+    end
+
+    test "specifies realm name", %{client: client} do
+      realm_name = @realm_name
+
+      Tesla.Mock.mock(fn %{body: body} ->
+        assert %{
+                 "data" => %{
+                   "realm_name" => ^realm_name
+                 }
+               } = Jason.decode!(body)
+
+        Tesla.Mock.json(realm_response(), status: 201)
+      end)
+
+      assert :ok = Realms.create(client, realm_name, @realm_public_key, replication_factor: 1)
+    end
+
+    test "specifies public key", %{client: client} do
+      realm_public_key = @realm_public_key
+
+      Tesla.Mock.mock(fn %{body: body} ->
+        assert %{
+                 "data" => %{
+                   "jwt_public_key_pem" => ^realm_public_key
+                 }
+               } = Jason.decode!(body)
+
+        Tesla.Mock.json(realm_response(), status: 201)
+      end)
+
+      assert :ok = Realms.create(client, @realm_name, realm_public_key, replication_factor: 1)
+    end
+
+    test "specifies integer device registration limit", %{client: client} do
+      opts = [device_registration_limit: 1]
+
+      Tesla.Mock.mock(fn %{body: body} ->
+        assert %{
+                 "data" => %{
+                   "device_registration_limit" => 1
+                 }
+               } = Jason.decode!(body)
+
+        Tesla.Mock.json(realm_response(), status: 201)
+      end)
+
+      assert :ok =
+               Realms.create(
+                 client,
+                 @realm_name,
+                 @realm_public_key,
+                 [replication_factor: 1] ++ opts
+               )
+    end
+
+    test "specifies nil device registration limit", %{client: client} do
+      opts = [device_registration_limit: nil]
+
+      Tesla.Mock.mock(fn %{body: body} ->
+        assert %{
+                 "data" => %{
+                   "device_registration_limit" => nil
+                 }
+               } = Jason.decode!(body)
+
+        Tesla.Mock.json(realm_response(), status: 201)
+      end)
+
+      assert :ok =
+               Realms.create(
+                 client,
+                 @realm_name,
+                 @realm_public_key,
+                 [replication_factor: 1] ++ opts
+               )
+    end
+
+    test "specifies nil without a defined device registration limit", %{client: client} do
+      Tesla.Mock.mock(fn %{body: body} ->
+        assert %{
+                 "data" => %{
+                   "device_registration_limit" => nil
+                 }
+               } = Jason.decode!(body)
+
+        Tesla.Mock.json(realm_response(), status: 201)
+      end)
+
+      assert :ok = Realms.create(client, @realm_name, @realm_public_key, replication_factor: 1)
+    end
+
+    test "specifies replication with simple strategy", %{client: client} do
+      opts = [replication_factor: 1]
+
+      Tesla.Mock.mock(fn %{body: body} ->
+        assert %{
+                 "data" => %{
+                   "replication_class" => "SimpleStrategy",
+                   "replication_factor" => 1
+                 }
+               } = Jason.decode!(body)
+
+        Tesla.Mock.json(realm_response(), status: 201)
+      end)
+
+      assert :ok = Realms.create(client, @realm_name, @realm_public_key, opts)
+    end
+
+    test "specifies replication with network topology strategy", %{client: client} do
+      opts = [datacenter_replication_factors: %{"DC1" => 3}]
+
+      Tesla.Mock.mock(fn %{body: body} ->
+        assert %{
+                 "data" => %{
+                   "replication_class" => "NetworkTopologyStrategy",
+                   "datacenter_replication_factors" => %{"DC1" => 3}
+                 }
+               } = Jason.decode!(body)
+
+        Tesla.Mock.json(realm_response(), status: 201)
+      end)
+
+      assert :ok = Realms.create(client, @realm_name, @realm_public_key, opts)
+    end
+
+    test "returns error if replication is not specified", %{client: client} do
+      assert {:error, :missing_replication} =
+               Realms.create(client, @realm_name, @realm_public_key, [])
+    end
+
+    test "retuns APIError on error", %{client: client} do
+      error_data = %{"errors" => %{"detail" => "Forbidden"}}
+      error_status = 403
+
+      Tesla.Mock.mock(fn %{} ->
+        Tesla.Mock.json(error_data, status: error_status)
+      end)
+
+      assert {:error, %APIError{response: error_data, status: error_status}} ==
+               Realms.create(client, @realm_name, @realm_public_key, replication_factor: 1)
+    end
+  end
+
+  describe "update/3" do
+    test "makes a request to expected url using expected method", %{client: client} do
+      Tesla.Mock.mock(fn %{method: method, url: url} ->
+        assert method == :patch
+        assert url == build_realm_url(@realm_name)
+
+        Tesla.Mock.json(
+          realm_response(),
+          status: 200
+        )
+      end)
+
+      Realms.update(client, @realm_name, [])
+    end
+
+    test "specifies public key", %{client: client} do
+      realm_public_key = @realm_public_key
+
+      Tesla.Mock.mock(fn %{body: body} ->
+        assert %{
+                 "data" => %{
+                   "jwt_public_key_pem" => ^realm_public_key
+                 }
+               } = Jason.decode!(body)
+
+        Tesla.Mock.json(realm_response(), status: 200)
+      end)
+
+      assert :ok = Realms.update(client, @realm_name, jwt_public_key_pem: realm_public_key)
+    end
+
+    test "specifies integer device registration limit", %{client: client} do
+      device_registration_limit = 1
+
+      Tesla.Mock.mock(fn %{body: body} ->
+        assert %{
+                 "data" => %{
+                   "device_registration_limit" => ^device_registration_limit
+                 }
+               } = Jason.decode!(body)
+
+        Tesla.Mock.json(realm_response(), status: 200)
+      end)
+
+      assert :ok =
+               Realms.update(client, @realm_name,
+                 device_registration_limit: device_registration_limit
+               )
+    end
+
+    test "specifies nil device registration limit", %{client: client} do
+      device_registration_limit = nil
+
+      Tesla.Mock.mock(fn %{body: body} ->
+        assert %{
+                 "data" => %{
+                   "device_registration_limit" => ^device_registration_limit
+                 }
+               } = Jason.decode!(body)
+
+        Tesla.Mock.json(realm_response(), status: 200)
+      end)
+
+      assert :ok =
+               Realms.update(client, @realm_name,
+                 device_registration_limit: device_registration_limit
+               )
+    end
+
+    test "does not specify device registration limit if undefined", %{client: client} do
+      Tesla.Mock.mock(fn %{body: body} ->
+        assert %{"data" => data} = Jason.decode!(body)
+        refute Map.has_key?(data, "device_registration_limit")
+
+        Tesla.Mock.json(realm_response(), status: 200)
+      end)
+
+      assert :ok = Realms.update(client, @realm_name, [])
+    end
+
+    test "retuns APIError on error", %{client: client} do
+      error_data = %{"errors" => %{"detail" => "Forbidden"}}
+      error_status = 403
+
+      Tesla.Mock.mock(fn %{} ->
+        Tesla.Mock.json(error_data, status: error_status)
+      end)
+
+      assert {:error, %APIError{response: error_data, status: error_status}} ==
+               Realms.update(client, @realm_name, [])
+    end
+  end
+
+  describe "delete/3" do
+    test "makes a request to expected url using expected method", %{client: client} do
+      Tesla.Mock.mock(fn %{method: method, url: url} ->
+        assert method == :delete
+        assert url == build_realm_url(@realm_name)
+
+        Tesla.Mock.json(
+          realm_response(),
+          status: 204
+        )
+      end)
+
+      Realms.delete(client, @realm_name, [])
+    end
+
+    test "specifies query parameters", %{client: client} do
+      opts = [query: [async_operation: false]]
+
+      Tesla.Mock.mock(fn %{query: query} ->
+        assert query == [async_operation: false]
+
+        Tesla.Mock.json(realm_response(), status: 204)
+      end)
+
+      assert :ok = Realms.delete(client, @realm_name, opts)
+    end
+
+    test "retuns APIError on error", %{client: client} do
+      error_data = %{"errors" => %{"detail" => "Forbidden"}}
+      error_status = 403
+
+      Tesla.Mock.mock(fn %{} ->
+        Tesla.Mock.json(error_data, status: error_status)
+      end)
+
+      assert {:error, %APIError{response: error_data, status: error_status}} ==
+               Realms.delete(client, @realm_name, [])
+    end
+  end
 
   describe "fetch_replication/1" do
     test "fetches valid replications" do
@@ -64,5 +475,37 @@ defmodule Astarte.Client.Housekeeping.RealmsTest do
     test "rejects opts without replication data" do
       assert {:error, :missing_replication} == Realms.fetch_replication([])
     end
+  end
+
+  defp build_realm_url(realm_name \\ "") do
+    Path.join([@base_url, "housekeeping", "v1", "realms", realm_name])
+  end
+
+  defp realm_response(opts \\ []) do
+    replication_data =
+      case Keyword.fetch(opts, :datacenter_replication_factors) do
+        {:ok, datacenter_replication_factors} ->
+          %{
+            "replication_class" => "NetworkTopologyStrategy",
+            "datacenter_replication_factors" => datacenter_replication_factors
+          }
+
+        :error ->
+          %{
+            "replication_class" => "SimpleStrategy",
+            "replication_factor" => opts[:replication_factor] || 1
+          }
+      end
+
+    %{
+      "data" =>
+        %{
+          "datastream_maximum_storage_retention" => nil,
+          "device_registration_limit" => opts[:device_registration_limit],
+          "jwt_public_key_pem" => opts[:jwt_public_key_pem] || @realm_public_key,
+          "realm_name" => opts[:realm_name] || @realm_name
+        }
+        |> Map.merge(replication_data)
+    }
   end
 end


### PR DESCRIPTION
- Support specifying a `device_registration_limit` options when calling the `Realms.create/4` function, which sets the device registration limit on the provisioned realm.
  The default value for the option is `nil`, i.e. no limit.
- Add a new `Realms.update/3` function to support updating the configuration of realms.
  The supported options are:
  - `jwt_public_key_pem` to update the realm's public key.
  - `device_registration_limit` to update the realm's device registration limit.
  By default, no options are defined and the update performs a no-op.