### PR TITLE
Support to get versions of microservices

### DIFF
--- a/lib/astarte/client/appengine/version.ex
+++ b/lib/astarte/client/appengine/version.ex
@@ -1,0 +1,34 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2024 SECO Mind
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Client.AppEngine.Version do
+  alias Astarte.Client.{APIError, AppEngine}
+
+  def get(%AppEngine{} = client) do
+    request_path = "version"
+    tesla_client = client.http_client
+
+    with {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path) do
+      if result.status == 200 do
+        {:ok, result.body}
+      else
+        {:error, %APIError{status: result.status, response: result.body}}
+      end
+    end
+  end
+end

--- a/lib/astarte/client/housekeeping/version.ex
+++ b/lib/astarte/client/housekeeping/version.ex
@@ -1,0 +1,34 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2024 SECO Mind
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Client.Housekeeping.Version do
+  alias Astarte.Client.{APIError, Housekeeping}
+
+  def get(%Housekeeping{} = client) do
+    request_path = "version"
+    tesla_client = client.http_client
+
+    with {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path) do
+      if result.status == 200 do
+        {:ok, result.body}
+      else
+        {:error, %APIError{status: result.status, response: result.body}}
+      end
+    end
+  end
+end

--- a/lib/astarte/client/pairing/version.ex
+++ b/lib/astarte/client/pairing/version.ex
@@ -1,0 +1,34 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2024 SECO Mind
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Client.Pairing.Version do
+  alias Astarte.Client.{APIError, Pairing}
+
+  def get(%Pairing{} = client) do
+    request_path = "version"
+    tesla_client = client.http_client
+
+    with {:ok, %Tesla.Env{} = result} <- Tesla.get(tesla_client, request_path) do
+      if result.status == 200 do
+        {:ok, result.body}
+      else
+        {:error, %APIError{status: result.status, response: result.body}}
+      end
+    end
+  end
+end

--- a/test/astarte/client/appengine/version_test.exs
+++ b/test/astarte/client/appengine/version_test.exs
@@ -1,0 +1,78 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2024 SECO Mind
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Client.AppEngine.VersionTest do
+  use ExUnit.Case
+  doctest Astarte.Client.AppEngine.Version
+
+  alias Astarte.Client.{APIError, AppEngine}
+  alias Astarte.Client.AppEngine.Version
+
+  @base_url "https://base-url.com"
+  @realm_name "realm_name"
+  @jwt "notarealjwt"
+  @version_data "1.1.1"
+
+  setup do
+    {:ok, %AppEngine{} = client} = AppEngine.new(@base_url, @realm_name, jwt: @jwt)
+
+    {:ok, client: client}
+  end
+
+  describe "get/2" do
+    test "makes a request to expected url using expected method", %{client: client} do
+      Tesla.Mock.mock(fn %{method: method, url: url} ->
+        assert method == :get
+        assert url == build_appengine_api_version_url()
+
+        Tesla.Mock.json(
+          %{"data" => @version_data},
+          status: 200
+        )
+      end)
+
+      Version.get(client)
+    end
+
+    test "returns app engine api version", %{client: client} do
+      version_data = %{"data" => @version_data}
+
+      Tesla.Mock.mock(fn _ ->
+        Tesla.Mock.json(version_data, status: 200)
+      end)
+
+      assert {:ok, version_data} == Version.get(client)
+    end
+
+    test "retuns APIError on error", %{client: client} do
+      error_data = %{"errors" => %{"detail" => "Forbidden"}}
+      error_status = 403
+
+      Tesla.Mock.mock(fn _ ->
+        Tesla.Mock.json(error_data, status: error_status)
+      end)
+
+      assert {:error, %APIError{response: error_data, status: error_status}} ==
+               Version.get(client)
+    end
+  end
+
+  defp build_appengine_api_version_url do
+    Path.join([@base_url, "appengine", "v1", @realm_name, "version"])
+  end
+end

--- a/test/astarte/client/housekeeping/version_test.exs
+++ b/test/astarte/client/housekeeping/version_test.exs
@@ -1,0 +1,77 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2024 SECO Mind
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Client.Housekeeping.VersionTest do
+  use ExUnit.Case
+  doctest Astarte.Client.Housekeeping.Version
+
+  alias Astarte.Client.{APIError, Housekeeping}
+  alias Astarte.Client.Housekeeping.Version
+
+  @base_url "https://base-url.com"
+  @jwt "notarealjwt"
+  @version_data "1.1.1"
+
+  setup do
+    {:ok, %Housekeeping{} = client} = Housekeeping.new(@base_url, jwt: @jwt)
+
+    {:ok, client: client}
+  end
+
+  describe "get/2" do
+    test "makes a request to expected url using expected method", %{client: client} do
+      Tesla.Mock.mock(fn %{method: method, url: url} ->
+        assert method == :get
+        assert url == build_housekeeping_api_version_url()
+
+        Tesla.Mock.json(
+          %{"data" => @version_data},
+          status: 200
+        )
+      end)
+
+      Version.get(client)
+    end
+
+    test "returns housekeeping api version", %{client: client} do
+      version_data = %{"data" => @version_data}
+
+      Tesla.Mock.mock(fn _ ->
+        Tesla.Mock.json(version_data, status: 200)
+      end)
+
+      assert {:ok, version_data} == Version.get(client)
+    end
+
+    test "retuns APIError on error", %{client: client} do
+      error_data = %{"errors" => %{"detail" => "Forbidden"}}
+      error_status = 403
+
+      Tesla.Mock.mock(fn _ ->
+        Tesla.Mock.json(error_data, status: error_status)
+      end)
+
+      assert {:error, %APIError{response: error_data, status: error_status}} ==
+               Version.get(client)
+    end
+  end
+
+  defp build_housekeeping_api_version_url do
+    Path.join([@base_url, "housekeeping", "v1", "version"])
+  end
+end

--- a/test/astarte/client/pairing/version_test.exs
+++ b/test/astarte/client/pairing/version_test.exs
@@ -1,0 +1,78 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2024 SECO Mind
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Client.Pairing.VersionTest do
+  use ExUnit.Case
+  doctest Astarte.Client.Pairing.Version
+
+  alias Astarte.Client.{APIError, Pairing}
+  alias Astarte.Client.Pairing.Version
+
+  @base_url "https://base-url.com"
+  @realm_name "realm_name"
+  @jwt "notarealjwt"
+  @version_data "1.1.1"
+
+  setup do
+    {:ok, %Pairing{} = client} = Pairing.new(@base_url, @realm_name, jwt: @jwt)
+
+    {:ok, client: client}
+  end
+
+  describe "get/2" do
+    test "makes a request to expected url using expected method", %{client: client} do
+      Tesla.Mock.mock(fn %{method: method, url: url} ->
+        assert method == :get
+        assert url == build_pairing_api_version_url()
+
+        Tesla.Mock.json(
+          %{"data" => @version_data},
+          status: 200
+        )
+      end)
+
+      Version.get(client)
+    end
+
+    test "returns pairing api version", %{client: client} do
+      version_data = %{"data" => @version_data}
+
+      Tesla.Mock.mock(fn _ ->
+        Tesla.Mock.json(version_data, status: 200)
+      end)
+
+      assert {:ok, version_data} == Version.get(client)
+    end
+
+    test "retuns APIError on error", %{client: client} do
+      error_data = %{"errors" => %{"detail" => "Forbidden"}}
+      error_status = 403
+
+      Tesla.Mock.mock(fn _ ->
+        Tesla.Mock.json(error_data, status: error_status)
+      end)
+
+      assert {:error, %APIError{response: error_data, status: error_status}} ==
+               Version.get(client)
+    end
+  end
+
+  defp build_pairing_api_version_url do
+    Path.join([@base_url, "pairing", "v1", @realm_name, "version"])
+  end
+end


### PR DESCRIPTION
Added the ```Astarte.Client.Housekeeping/AppEngine/Pairing.Version``` modules with get/1
functions that return version for every microservice independently.