### PR TITLE
feat: add datastream maximum storage retention to realms

### DIFF
--- a/lib/astarte/client/housekeeping/realms.ex
+++ b/lib/astarte/client/housekeeping/realms.ex
@@ -49,10 +49,14 @@ defmodule Astarte.Client.Housekeeping.Realms do
     query = Keyword.get(opts, :query, [])
     device_registration_limit = Keyword.get(opts, :device_registration_limit)
 
+    datastream_maximum_storage_retention =
+      Keyword.get(opts, :datastream_maximum_storage_retention)
+
     data = %{
       realm_name: realm_name,
       jwt_public_key_pem: public_key_pem,
-      device_registration_limit: device_registration_limit
+      device_registration_limit: device_registration_limit,
+      datastream_maximum_storage_retention: datastream_maximum_storage_retention
     }
 
     with {:ok, replication_data} <- fetch_replication(opts),
@@ -141,7 +145,7 @@ defmodule Astarte.Client.Housekeeping.Realms do
     tesla_client = client.http_client
 
     realm_data =
-      [:jwt_public_key_pem, :device_registration_limit]
+      [:jwt_public_key_pem, :device_registration_limit, :datastream_maximum_storage_retention]
       |> Enum.reduce(%{}, fn key, acc ->
         case Keyword.fetch(opts, key) do
           {:ok, value} -> Map.put(acc, key, value)

--- a/test/astarte/client/housekeeping/realms_test.exs
+++ b/test/astarte/client/housekeeping/realms_test.exs
@@ -248,6 +248,64 @@ defmodule Astarte.Client.Housekeeping.RealmsTest do
       assert :ok = Realms.create(client, @realm_name, @realm_public_key, replication_factor: 1)
     end
 
+    test "specifies integer datastream maximum storage retention", %{client: client} do
+      opts = [datastream_maximum_storage_retention: 1]
+
+      Tesla.Mock.mock(fn %{body: body} ->
+        assert %{
+                 "data" => %{
+                   "datastream_maximum_storage_retention" => 1
+                 }
+               } = Jason.decode!(body)
+
+        Tesla.Mock.json(realm_response(), status: 201)
+      end)
+
+      assert :ok =
+               Realms.create(
+                 client,
+                 @realm_name,
+                 @realm_public_key,
+                 [replication_factor: 1] ++ opts
+               )
+    end
+
+    test "specifies nil datastream maximum storage retention", %{client: client} do
+      opts = [datastream_maximum_storage_retention: nil]
+
+      Tesla.Mock.mock(fn %{body: body} ->
+        assert %{
+                 "data" => %{
+                   "datastream_maximum_storage_retention" => nil
+                 }
+               } = Jason.decode!(body)
+
+        Tesla.Mock.json(realm_response(), status: 201)
+      end)
+
+      assert :ok =
+               Realms.create(
+                 client,
+                 @realm_name,
+                 @realm_public_key,
+                 [replication_factor: 1] ++ opts
+               )
+    end
+
+    test "specifies nil without a defined datastream maximum storage retention", %{client: client} do
+      Tesla.Mock.mock(fn %{body: body} ->
+        assert %{
+                 "data" => %{
+                   "datastream_maximum_storage_retention" => nil
+                 }
+               } = Jason.decode!(body)
+
+        Tesla.Mock.json(realm_response(), status: 201)
+      end)
+
+      assert :ok = Realms.create(client, @realm_name, @realm_public_key, replication_factor: 1)
+    end
+
     test "specifies replication with simple strategy", %{client: client} do
       opts = [replication_factor: 1]
 
@@ -380,6 +438,55 @@ defmodule Astarte.Client.Housekeeping.RealmsTest do
       assert :ok = Realms.update(client, @realm_name, [])
     end
 
+    test "specifies integer datastream maximum storage retention", %{client: client} do
+      datastream_maximum_storage_retention = 1
+
+      Tesla.Mock.mock(fn %{body: body} ->
+        assert %{
+                 "data" => %{
+                   "datastream_maximum_storage_retention" => ^datastream_maximum_storage_retention
+                 }
+               } = Jason.decode!(body)
+
+        Tesla.Mock.json(realm_response(), status: 200)
+      end)
+
+      assert :ok =
+               Realms.update(client, @realm_name,
+                 datastream_maximum_storage_retention: datastream_maximum_storage_retention
+               )
+    end
+
+    test "specifies nil datastream maximum storage retention", %{client: client} do
+      datastream_maximum_storage_retention = nil
+
+      Tesla.Mock.mock(fn %{body: body} ->
+        assert %{
+                 "data" => %{
+                   "datastream_maximum_storage_retention" => ^datastream_maximum_storage_retention
+                 }
+               } = Jason.decode!(body)
+
+        Tesla.Mock.json(realm_response(), status: 200)
+      end)
+
+      assert :ok =
+               Realms.update(client, @realm_name,
+                 datastream_maximum_storage_retention: datastream_maximum_storage_retention
+               )
+    end
+
+    test "does not specify datastream maximum storage retention if undefined", %{client: client} do
+      Tesla.Mock.mock(fn %{body: body} ->
+        assert %{"data" => data} = Jason.decode!(body)
+        refute Map.has_key?(data, "datastream_maximum_storage_retention")
+
+        Tesla.Mock.json(realm_response(), status: 200)
+      end)
+
+      assert :ok = Realms.update(client, @realm_name, [])
+    end
+
     test "retuns APIError on error", %{client: client} do
       error_data = %{"errors" => %{"detail" => "Forbidden"}}
       error_status = 403
@@ -500,7 +607,7 @@ defmodule Astarte.Client.Housekeeping.RealmsTest do
     %{
       "data" =>
         %{
-          "datastream_maximum_storage_retention" => nil,
+          "datastream_maximum_storage_retention" => opts[:datastream_maximum_storage_retention],
           "device_registration_limit" => opts[:device_registration_limit],
           "jwt_public_key_pem" => opts[:jwt_public_key_pem] || @realm_public_key,
           "realm_name" => opts[:realm_name] || @realm_name


### PR DESCRIPTION
This change adds support for the `datastream_maximum_storage_retention` configuration option when creating or updating realms via the Housekeeping client.

Includes tests to verify proper handling of integer, nil, and undefined values.